### PR TITLE
Fix README.md sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The packagist job created for your update.
 ## Example usage
 
 ```yaml
-uses: mnavarrocarter/packagist-update@v1.0
+uses: mnavarrocarter/packagist-update@v1.0.0
 with:
   username: "your-username"
   api_token: ${{ secrets.packagist_token }}


### PR DESCRIPTION
We have to specify the full version `v1.0.0` for it to work.